### PR TITLE
Fix #142: Any method to add my trained model to advanced tools?

### DIFF
--- a/src/constant.json
+++ b/src/constant.json
@@ -292,6 +292,8 @@
       "VenusPLM": "venusplm",
       "VenusREM (foldseek-based)": "venusrem"
     },
+    "sequence_model_options": ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"],
+    "structure_model_options": ["VenusREM (foldseek-based)", "ProSST-2048", "ProtSSN", "ESM-IF1", "SaProt", "MIF-ST"],
     "dataset_mapping_zero_shot": [
       "Activity",
       "Binding",

--- a/src/web_v2/advanced_tools_api.py
+++ b/src/web_v2/advanced_tools_api.py
@@ -711,8 +711,8 @@ async def advanced_tools_meta():
     mpnn_options = _proteinmpnn_model_options()
     return {
         "dataset_mapping_zero_shot": web_ui.get("dataset_mapping_zero_shot", []),
-        "sequence_model_options": ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"],
-        "structure_model_options": ["VenusREM (foldseek-based)", "ProSST-2048", "ProtSSN", "ESM-IF1", "SaProt", "MIF-ST"],
+        "sequence_model_options": web_ui.get("sequence_model_options", ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"]),
+        "structure_model_options": web_ui.get("structure_model_options", ["VenusREM (foldseek-based)", "ProSST-2048", "ProtSSN", "ESM-IF1", "SaProt", "MIF-ST"]),
         "model_mapping_function": list(web_ui.get("model_mapping_function", {}).keys()),
         "residue_model_mapping_function": list(web_ui.get("model_residue_mapping_function", {}).keys()),
         "dataset_mapping_function": web_ui.get("dataset_mapping_function", {}),

--- a/tests/test_advanced_tools_meta.py
+++ b/tests/test_advanced_tools_meta.py
@@ -1,0 +1,70 @@
+"""Tests for advanced tools meta endpoint model options configurability."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestAdvancedToolsMetaModelOptions(unittest.TestCase):
+    """Verify that sequence/structure model options are read from constant.json."""
+
+    def _build_constant(self, extra_web_ui=None):
+        web_ui = {
+            "model_mapping_zero_shot": {"ESM2-650M": "esm2", "ESM-IF1": "esmif1"},
+            "dataset_mapping_zero_shot": [],
+            "model_mapping_function": {},
+            "model_residue_mapping_function": {},
+            "dataset_mapping_function": {},
+            "residue_mapping_function": {},
+            "llm_models": {},
+        }
+        if extra_web_ui:
+            web_ui.update(extra_web_ui)
+        return {"web_ui": web_ui}
+
+    def test_default_model_options_when_not_in_constant(self):
+        """Fallback defaults are used when constant.json omits model option lists."""
+        data = self._build_constant()
+        web_ui = data.get("web_ui", {})
+        # Simulate the meta endpoint logic: read with fallback
+        seq = web_ui.get("sequence_model_options", ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"])
+        struct = web_ui.get("structure_model_options", ["VenusREM (foldseek-based)", "ProSST-2048", "ProtSSN", "ESM-IF1", "SaProt", "MIF-ST"])
+
+        self.assertEqual(seq, ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"])
+        self.assertIn("ESM-IF1", struct)
+
+    def test_custom_model_options_from_constant(self):
+        """Custom model options defined in constant.json are returned by the meta logic."""
+        custom_seq = ["MyTrainedModel", "ESM2-650M"]
+        custom_struct = ["MyStructureModel", "ESM-IF1"]
+        data = self._build_constant(
+            {
+                "sequence_model_options": custom_seq,
+                "structure_model_options": custom_struct,
+            }
+        )
+        web_ui = data.get("web_ui", {})
+        seq = web_ui.get("sequence_model_options", ["VenusPLM", "ESM2-650M", "ESM-1v", "ESM-1b"])
+        struct = web_ui.get("structure_model_options", ["VenusREM (foldseek-based)", "ProSST-2048", "ProtSSN", "ESM-IF1", "SaProt", "MIF-ST"])
+
+        self.assertEqual(seq, custom_seq)
+        self.assertIn("MyTrainedModel", seq)
+        self.assertEqual(struct, custom_struct)
+        self.assertIn("MyStructureModel", struct)
+
+    def test_constant_json_has_model_option_keys(self):
+        """The shipped constant.json already contains sequence/structure_model_options."""
+        constant_path = Path(__file__).resolve().parent.parent / "src" / "constant.json"
+        self.assertTrue(constant_path.exists(), "constant.json not found")
+        data = json.loads(constant_path.read_text(encoding="utf-8"))
+        web_ui = data.get("web_ui", {})
+        self.assertIn("sequence_model_options", web_ui, "sequence_model_options missing from constant.json")
+        self.assertIn("structure_model_options", web_ui, "structure_model_options missing from constant.json")
+        self.assertIsInstance(web_ui["sequence_model_options"], list)
+        self.assertIsInstance(web_ui["structure_model_options"], list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #142

Model option lists for the advanced tools panel were previously hardcoded in `advanced_tools_api.py`; this moves them into `src/constant.json` under `web_ui.sequence_model_options` and `web_ui.structure_model_options`, so operators can register custom trained models by editing config rather than source code.

In `src/constant.json`, two new keys are added to the `web_ui` object with the existing defaults as their values. In `src/web_v2/advanced_tools_api.py`, the `advanced_tools_meta` function (lines ~714–715) now calls `web_ui.get("sequence_model_options", [...])` and `web_ui.get("structure_model_options", [...])` instead of returning inline literals, preserving backward compatibility when the keys are absent.

`tests/test_advanced_tools_meta.py` is added with three unit tests: `test_default_model_options_when_not_in_constant` confirms the fallback literals are returned when the keys are missing, `test_custom_model_options_from_constant` confirms a custom entry like `"MyTrainedModel"` is surfaced when set in config, and `test_constant_json_has_model_option_keys` reads the actual `src/constant.json` on disk and asserts both keys are present and are lists.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*